### PR TITLE
Fix 'IndexError: list index out of range' error when working with a completely empty Gitlab repository.

### DIFF
--- a/pv2/util/gitutil.py
+++ b/pv2/util/gitutil.py
@@ -149,7 +149,6 @@ def lsremote(url):
     # pylint: disable=no-member
     except gitexc.CommandError as exc:
         print(f'Repo does not exist or is not accessible: {exc.stderr}')
-        print('TEST:', url)
         return None
 
     for ref in git_cmd.ls_remote(url).split('\n'):

--- a/pv2/util/gitutil.py
+++ b/pv2/util/gitutil.py
@@ -149,9 +149,14 @@ def lsremote(url):
     # pylint: disable=no-member
     except gitexc.CommandError as exc:
         print(f'Repo does not exist or is not accessible: {exc.stderr}')
+        print('TEST:', url)
         return None
 
     for ref in git_cmd.ls_remote(url).split('\n'):
         hash_ref_list = ref.split('\t')
-        remote_refs[hash_ref_list[1]] = hash_ref_list[0]
+        # Solves "IndexError: list index out of range" error when working 
+        # with a completely empty Gitlab repository.
+        # (Initialized without README in the web interface)
+        if len(hash_ref_list) > 1:
+            remote_refs[hash_ref_list[1]] = hash_ref_list[0]
     return remote_refs


### PR DESCRIPTION
## Proposed Commit Message
 Fix 'IndexError: list index out of range' error when working with a completely empty Gitlab repository.

```
Summary:
Solves "IndexError: list index out of range" error when working
with a completely empty Gitlab repository.
(Initialized without README in the web interface)
```

## Testing/Verification
Recreate issue:
- Create an imports group on Gitlab
- Create a sub-group under imports called "rpms"
- Create blank project under imports/rpms and uncheck "Initialize repository with a README " on Gitlab web interface
- Download source RPM to use with examples/import_pkg.py (example: https://kojihub.stream.centos.org/koji/buildinfo?buildID=27195)
- run "python3 import_pkg.py --giturl gitlab.some.project/imports --branch c9s --srpm bash-5.1.8-6.el9.src.rpm"
- You should be asked to enter a passphrase for an SSH key (Which I assume you already have setup)
- You should be asked again to enter a passphrase for an SSH key

After fix:
You do essentially the same steps as above. The minor difference being that you don't have to recreate your gitlab repo.

After that you'll most likely get an error about not being able to access /var/www/html/sources. A quick fix for that is as follows:
- sudo mkdir /var/www/html/sources
- sudo chown `whoami`:`whoami` /var/www/html/sources
